### PR TITLE
Uniformize short dev doc to track tensor shapes in solvers

### DIFF
--- a/dynamiqs/mesolve/adaptive.py
+++ b/dynamiqs/mesolve/adaptive.py
@@ -7,16 +7,18 @@ from ..utils.solver_utils import kraus_map
 class MEAdaptive(AdaptiveSolver):
     def __init__(self, *args, jump_ops: Tensor):
         super().__init__(*args)
-
         self.jump_ops = jump_ops[None, ...]  # (1, len(jump_ops), n, n)
         self.sum_nojump = (jump_ops.adjoint() @ jump_ops).sum(dim=0)  # (n, n)
 
     def odefun(self, t: float, rho: Tensor) -> Tensor:
         """Compute drho / dt = L(rho) at time t."""
+        # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
+
         # non-hermitian Hamiltonian
-        H_nh = self.H(t) - 0.5j * self.sum_nojump
+        H_nh = self.H(t) - 0.5j * self.sum_nojump  # (b_H, 1, n, n)
 
         # compute Lindblad(t) @ rho
-        H_nh_rho = H_nh @ rho
-        L_rho_Ldag = kraus_map(rho, self.jump_ops)
+        H_nh_rho = H_nh @ rho  # (b_H, b_rho, n, n)
+        L_rho_Ldag = kraus_map(rho, self.jump_ops)  # (b_H, b_rho, n, n)
+
         return -1j * (H_nh_rho - H_nh_rho.adjoint()) + L_rho_Ldag

--- a/dynamiqs/mesolve/euler.py
+++ b/dynamiqs/mesolve/euler.py
@@ -7,14 +7,8 @@ from ..utils.solver_utils import lindbladian
 class MEEuler(ForwardSolver):
     def __init__(self, *args, jump_ops: Tensor):
         super().__init__(*args)
-
         self.jump_ops = jump_ops  # (len(jump_ops), n, n)
 
     def forward(self, t: float, dt: float, rho: Tensor) -> Tensor:
-        # Args:
-        #     rho: (b_H, b_rho, n, n)
-        #
-        # Returns:
-        #     (b_H, b_rho, n, n)
-
+        # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         return rho + dt * lindbladian(rho, self.H(t), self.jump_ops)

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -13,11 +13,6 @@ from ..utils.utils import trace
 
 class MERouchon(AdjointForwardSolver):
     def __init__(self, *args, jump_ops: Tensor):
-        """
-        Args:
-            H: Hamiltonian, of shape `(b_H, n, n)`.
-            jump_ops: Jump operators, of shape `(len(jump_ops), n, n)`.
-        """
         super().__init__(*args)
 
         self.n = self.H.size(-1)
@@ -28,26 +23,30 @@ class MERouchon(AdjointForwardSolver):
         self.sum_nojump = (jump_ops.adjoint() @ jump_ops).sum(dim=0)  # (n, n)
 
         self.M1s = sqrt(self.dt) * self.jump_ops  # (1, len(jump_ops), n, n)
-        self.M1s_adj = sqrt(self.dt) * self.jump_ops.adjoint()
+        self.M1s_adj = self.M1s.adjoint()  # (1, len(jump_ops), n, n)
 
 
 class MERouchon1(MERouchon):
     @depends_on_H
     def H_nh(self, t: float) -> Tensor:
         # non-hermitian Hamiltonian at time t
-        return self.H(t) - 0.5j * self.sum_nojump  # (b_H, 1, n, n)
+        # -> (b_H, 1, n, n)
+        return self.H(t) - 0.5j * self.sum_nojump
 
     @depends_on_H
     def Hdag_nh(self, t: float) -> Tensor:
+        # -> (b_H, 1, n, n)
         return self.H_nh(t).adjoint()
 
     @depends_on_H
     def M0(self, t: float, dt: float) -> Tensor:
         # build time-dependent Kraus operators
-        return self.I - 1j * dt * self.H_nh(t)  # (b_H, 1, n, n)
+        # -> (b_H, 1, n, n)
+        return self.I - 1j * dt * self.H_nh(t)
 
     @depends_on_H
     def M0_adj(self, t: float, dt: float) -> Tensor:
+        # -> (b_H, 1, n, n)
         return self.I + 1j * dt * self.Hdag_nh(t)
 
     def forward(self, t: float, dt: float, rho: Tensor) -> Tensor:
@@ -60,18 +59,17 @@ class MERouchon1(MERouchon):
         Returns:
             Density matrix at next time step, as tensor of shape `(b_H, b_rho, n, n)`.
         """
+        # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
+
         # compute rho(t+dt)
         rho = kraus_map(rho, self.M0(t, dt)) + kraus_map(rho, self.M1s)
+        # rho: (b_H, b_rho, n, n)
 
         # normalize by the trace
-        rho = rho / trace(rho)[..., None, None].real
-
-        return rho
+        return rho / trace(rho)[..., None, None].real
 
     def backward_augmented(self, t: float, dt: float, rho: Tensor, phi: Tensor):
         r"""Compute $\rho(t-dt)$ and $\phi(t-dt)$ using a Rouchon method of order 1."""
-        # non-hermitian Hamiltonian at time t
-
         # compute rho(t-dt)
         rho = kraus_map(rho, self.M0(t, dt)) - kraus_map(rho, self.M1s)
         rho = rho / trace(rho)[..., None, None].real
@@ -105,6 +103,8 @@ class MERouchon1_5(MERouchon):
         Returns:
             Density matrix at next time step, as tensor of shape `(b_H, b_rho, n, n)`.
         """
+        # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
+
         # non-hermitian Hamiltonian at time t
         H_nh = self.H - 0.5j * self.sum_nojump  # (b_H, 1, n, n)
 
@@ -118,8 +118,8 @@ class MERouchon1_5(MERouchon):
         S_inv_sqrtm = inv_sqrtm(S)  # (b_H, 1, n, n)
 
         # compute rho(t+dt)
-        rho = kraus_map(rho, S_inv_sqrtm)
-        rho = kraus_map(rho, M0) + kraus_map(rho, Ms)
+        rho = kraus_map(rho, S_inv_sqrtm)  # (b_H, b_rho, n, n)
+        rho = kraus_map(rho, M0) + kraus_map(rho, Ms)  # (b_H, b_rho, n, n)
 
         return rho
 
@@ -144,22 +144,23 @@ class MERouchon2(MERouchon):
         Returns:
             Density matrix at next time step, as tensor of shape `(b_H, b_rho, n, n)`.
         """
+        # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
+
         # non-hermitian Hamiltonian at time t
         H_nh = self.H(t) - 0.5j * self.sum_nojump  # (b_H, 1, n, n)
 
         # build time-dependent Kraus operators
-        # M0: (b_H, 1, n, n)
         M0 = self.I - 1j * dt * H_nh - 0.5 * self.dt**2 * H_nh @ H_nh
-        M1s = (
-            0.5 * sqrt(dt) * (self.jump_ops @ M0 + M0 @ self.jump_ops)
-        )  # (b_H, len(jump_ops), n, n)
+        # M0: (b_H, 1, n, n)
+        M1s = 0.5 * sqrt(dt) * (self.jump_ops @ M0 + M0 @ self.jump_ops)
+        # M1s: (b_H, len(jump_ops), n, n)
 
         # compute rho(t+dt)
-        tmp = kraus_map(rho, M1s)
-        rho = kraus_map(rho, M0) + tmp + 0.5 * kraus_map(tmp, M1s)
+        tmp = kraus_map(rho, M1s)  # (b_H, b_rho, n, n)
+        rho = kraus_map(rho, M0) + tmp + 0.5 * kraus_map(tmp, M1s)  # (b_H, b_rho, n, n)
 
         # normalize by the trace
-        rho = rho / trace(rho)[..., None, None].real
+        rho = rho / trace(rho)[..., None, None].real  # (b_H, b_rho, n, n)
 
         return rho
 

--- a/dynamiqs/sesolve/adaptive.py
+++ b/dynamiqs/sesolve/adaptive.py
@@ -6,4 +6,5 @@ from ..solvers.ode.adaptive_solver import AdaptiveSolver
 class SEAdaptive(AdaptiveSolver):
     def odefun(self, t: float, psi: Tensor) -> Tensor:
         """Compute dpsi / dt = -1j * H(psi) at time t."""
+        # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
         return -1j * self.H(t) @ psi

--- a/dynamiqs/sesolve/euler.py
+++ b/dynamiqs/sesolve/euler.py
@@ -5,10 +5,5 @@ from ..solvers.ode.forward_solver import ForwardSolver
 
 class SEEuler(ForwardSolver):
     def forward(self, t: float, dt: float, psi: Tensor) -> Tensor:
-        # Args:
-        #     psi: (b_H, b_psi, n, 1)
-        #
-        # Returns:
-        #     (b_H, b_psi, n, 1)
-
+        # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
         return psi - dt * 1j * self.H(t) @ psi

--- a/dynamiqs/sesolve/propagator.py
+++ b/dynamiqs/sesolve/propagator.py
@@ -1,8 +1,10 @@
 import torch
+from torch import Tensor
 
 from ..solvers.propagator import Propagator
 
 
 class SEPropagator(Propagator):
-    def forward(self, t, dt, psi):
+    def forward(self, t: float, dt: float, psi: Tensor) -> Tensor:
+        # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
         return torch.matrix_exp(-1j * self.H(t) * dt) @ psi

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -26,21 +26,19 @@ def sesolve(
     dtype: torch.complex64 | torch.complex128 | None = None,
     device: torch.device | None = None,
 ) -> tuple[Tensor, Tensor | None]:
-    # Args:
-    #     H: (b_H?, n, n)
-    #     psi0: (b_psi0?, n, 1)
-    #
-    # Returns:
-    #     (y_save, exp_save) with
-    #     - y_save: (b_H?, b_psi0?, len(t_save), n, 1)
-    #     - exp_save: (b_H?, b_psi0?, len(exp_ops), len(t_save))
+    # H: (b_H?, n, n), psi0: (b_psi0?, n, 1) -> (y_save, exp_save) with
+    #    - y_save: (b_H?, b_psi0?, len(t_save), n, 1)
+    #    - exp_save: (b_H?, b_psi0?, len(exp_ops), len(t_save))
+
     # TODO support density matrices too
     # TODO add test to check that psi0 has the correct shape
 
     # format and batch all tensors
     formatter = TensorFormatter(dtype, device)
     H_batched, psi0_batched = formatter.format_H_and_state(H, psi0)
-    exp_ops = formatter.format(exp_ops)
+    # H_batched: (b_H, 1, n, n)
+    # psi0_batched: (1, b_psi0, n, 1)
+    exp_ops = formatter.format(exp_ops)  # (len(exp_ops), n, n)
 
     # convert t_save to tensor
     t_save = torch.as_tensor(t_save, dtype=dtype_complex_to_real(dtype), device=device)
@@ -49,13 +47,7 @@ def sesolve(
     options = options or Dopri5()
 
     # define the solver
-    args = (
-        H_batched,
-        psi0_batched,
-        t_save,
-        exp_ops,
-        options,
-    )
+    args = (H_batched, psi0_batched, t_save, exp_ops, options)
     if isinstance(options, Euler):
         solver = SEEuler(*args)
     elif isinstance(options, ODEAdaptiveStep):


### PR DESCRIPTION
I think following the tensor shapes is really hard if we don't force ourselves to inline comment, although it's a bit annoying to do. What do you guys think?

I didn't do the `backward_augmented` methods of the mesolve Rouchon solvers. @gautierronan if you have the motivation to add it 😉 